### PR TITLE
[CI/CD] apps/server에 대한 dependabot automerge 구축

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -5,8 +5,8 @@ on:
       - master
     types: [opened, synchronize]
     paths:
-      - "package.json"
-      - "packages/api/package.json"
+      - "apps/server/package.json"
+      - "apps/server/packages/api/package.json"
 jobs:
   build-and-merge:
     if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'


### PR DESCRIPTION
## PR Desciption

> 변경 사항 설명

- apps/server package의 변동에 반응하는 automerge system 구축

## PR Log

> PR 작업하면서 고민했던 내용, 해결한 내용, 고민 중인 내용 등

### 추가로 작업해야 하는 사항

[api packages output 위치 조정]
`apps/server`에서 build를 하면 `packages/api`가 나온다.
우리는 이 `packages`를 `apps/web`에서 api 호출 위한 코드로 사용할 예정이기 때문에,
해당 build의 output을 `./apps/server/packages`에서 `./packages`로 조정하고
`apps/web`에서도 해당 package를 참조하도록 해야할 것 같다.

## 관련 이슈

- #10 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow triggers for automated dependency merging to monitor different package locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->