### PR TITLE
dependabot triger for web

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,3 +49,36 @@ updates:
           - "typia"
           - "tgrid"
 #######################################################
+  - package-ecosystem: 'npm'
+    directory: '/apps/web'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 25
+    versioning-strategy: increase
+    allow:
+      - dependency-name: "vite"
+      - dependency-name: "vitest"
+      - dependency-name: "vite-tsconfig-paths"
+      - dependency-name: "@vitejs/plugin-react"
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "@types/react"
+      - dependency-name: "@types/react-dom"
+      - dependency-name: "typescript"
+    groups:
+      Vite:
+        patterns:
+          - "vite"
+          - "vitest"
+          - "vite-tsconfig-paths"
+          - "@vitejs/plugin-react"
+      React:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      Typescript:
+        patterns:
+          - "typescript"
+ 

--- a/apps/server/src/api/graphql/operations.ts
+++ b/apps/server/src/api/graphql/operations.ts
@@ -1728,7 +1728,7 @@ export type CancelEnterpriseMemberInvitationPayload = {
   clientMutationId: Maybe<Scalars['String']['output']>;
   /** The invitation that was canceled. */
   invitation: Maybe<EnterpriseMemberInvitation>;
-  /** A message confirming the result of canceling an member invitation. */
+  /** A message confirming the result of canceling a member invitation. */
   message: Maybe<Scalars['String']['output']>;
 };
 
@@ -2027,7 +2027,7 @@ export type CheckRunFilter = {
   checkType: InputMaybe<CheckRunType>;
   /** Filters the check runs by these conclusions. */
   conclusions: InputMaybe<Array<CheckConclusionState>>;
-  /** Filters the check runs by this status. Superceded by statuses. */
+  /** Filters the check runs by this status. Superseded by statuses. */
   status: InputMaybe<CheckStatusState>;
   /** Filters the check runs by this status. Overrides status. */
   statuses: InputMaybe<Array<CheckStatusState>>;
@@ -6882,13 +6882,13 @@ export type EnablePullRequestAutoMergeInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId: InputMaybe<Scalars['String']['input']>;
   /**
-   * Commit body to use for the commit when the PR is mergable; if omitted, a
+   * Commit body to use for the commit when the PR is mereabel; if omitted, a
    * default message will be used. NOTE: when merging with a merge queue any input
    * value for commit message is ignored.
    */
   commitBody: InputMaybe<Scalars['String']['input']>;
   /**
-   * Commit headline to use for the commit when the PR is mergable; if omitted, a
+   * Commit headline to use for the commit when the PR is mereabel; if omitted, a
    * default message will be used. NOTE: when merging with a merge queue any input
    * value for commit headline is ignored.
    */
@@ -11796,7 +11796,7 @@ export type MergeQueueConfiguration = {
   /** The minimum number of entries required to merge at once. */
   minimumEntriesToMerge: Maybe<Scalars['Int']['output']>;
   /**
-   * The amount of time in minutes to wait before ignoring the minumum number of
+   * The amount of time in minutes to wait before ignoring the minimum number of
    * entries in the queue requirement and merging a collection of entries
    */
   minimumEntriesToMergeWaitTime: Maybe<Scalars['Int']['output']>;
@@ -11894,7 +11894,7 @@ export enum MergeQueueMergeMethod {
 export enum MergeQueueMergingStrategy {
   /** Entries only allowed to merge if they are passing. */
   Allgreen = 'ALLGREEN',
-  /** Failing Entires are allowed to merge if they are with a passing entry. */
+  /** Failing Entries are allowed to merge if they are with a passing entry. */
   Headgreen = 'HEADGREEN'
 }
 
@@ -21306,7 +21306,7 @@ export type ProjectV2View = Node & {
   fullDatabaseId: Maybe<Scalars['BigInt']['output']>;
   /**
    * The view's group-by field.
-   * @deprecated The `ProjectV2View#order_by` API is deprecated in favour of the more capable `ProjectV2View#group_by_field` API. Check out the `ProjectV2View#group_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC.
+   * @deprecated The `ProjectV2View#order_by` API is deprecated in favor of the more capable `ProjectV2View#group_by_field` API. Check out the `ProjectV2View#group_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC.
    */
   groupBy: Maybe<ProjectV2FieldConnection>;
   /** The view's group-by field. */
@@ -21323,7 +21323,7 @@ export type ProjectV2View = Node & {
   project: ProjectV2;
   /**
    * The view's sort-by config.
-   * @deprecated The `ProjectV2View#sort_by` API is deprecated in favour of the more capable `ProjectV2View#sort_by_fields` API. Check out the `ProjectV2View#sort_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC.
+   * @deprecated The `ProjectV2View#sort_by` API is deprecated in favor of the more capable `ProjectV2View#sort_by_fields` API. Check out the `ProjectV2View#sort_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC.
    */
   sortBy: Maybe<ProjectV2SortByConnection>;
   /** The view's sort-by config. */
@@ -21332,14 +21332,14 @@ export type ProjectV2View = Node & {
   updatedAt: Scalars['DateTime']['output'];
   /**
    * The view's vertical-group-by field.
-   * @deprecated The `ProjectV2View#vertical_group_by` API is deprecated in favour of the more capable `ProjectV2View#vertical_group_by_fields` API. Check out the `ProjectV2View#vertical_group_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC.
+   * @deprecated The `ProjectV2View#vertical_group_by` API is deprecated in favor of the more capable `ProjectV2View#vertical_group_by_fields` API. Check out the `ProjectV2View#vertical_group_by_fields` API as an example for the more capable alternative. Removal on 2023-04-01 UTC.
    */
   verticalGroupBy: Maybe<ProjectV2FieldConnection>;
   /** The view's vertical-group-by field. */
   verticalGroupByFields: Maybe<ProjectV2FieldConfigurationConnection>;
   /**
    * The view's visible fields.
-   * @deprecated The `ProjectV2View#visibleFields` API is deprecated in favour of the more capable `ProjectV2View#fields` API. Check out the `ProjectV2View#fields` API as an example for the more capable alternative. Removal on 2023-01-01 UTC.
+   * @deprecated The `ProjectV2View#visibleFields` API is deprecated in favor of the more capable `ProjectV2View#fields` API. Check out the `ProjectV2View#fields` API as an example for the more capable alternative. Removal on 2023-01-01 UTC.
    */
   visibleFields: Maybe<ProjectV2FieldConnection>;
 };
@@ -23784,7 +23784,7 @@ export type ReferencedEvent = Node & {
   subject: ReferencedSubject;
 };
 
-/** Any referencable object */
+/** Any referenceable object */
 export type ReferencedSubject = Issue | PullRequest;
 
 /** Autogenerated input type of RegenerateEnterpriseIdentityProviderRecoveryCodes */
@@ -32892,9 +32892,9 @@ export enum ThreadSubscriptionState {
   IgnoringList = 'IGNORING_LIST',
   /** The User is never notified because they are ignoring the thread */
   IgnoringThread = 'IGNORING_THREAD',
-  /** The User is not recieving notifications from this thread */
+  /** The User is not receiving notifications from this thread */
   None = 'NONE',
-  /** The User is notified becuase they are watching the list */
+  /** The User is notified because they are watching the list */
   SubscribedToList = 'SUBSCRIBED_TO_LIST',
   /** The User is notified because they are subscribed to the thread */
   SubscribedToThread = 'SUBSCRIBED_TO_THREAD',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,11 +49,11 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0(graphql@16.11.0)
       '@nestia/core':
-        specifier: ^7.3.1
-        version: 7.3.2(@nestia/fetcher@7.3.2)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.0(typescript@5.9.2))
+        specifier: ^7.3.3
+        version: 7.3.3(@nestia/fetcher@7.3.3)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2))
       '@nestia/fetcher':
-        specifier: ^7.3.1
-        version: 7.3.2
+        specifier: ^7.3.3
+        version: 7.3.3
       '@nestjs/apollo':
         specifier: ^13.1.0
         version: 13.1.0(@apollo/server@5.0.0(graphql@16.11.0))(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@nestjs/graphql@13.1.0(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(graphql@16.11.0)(reflect-metadata@0.2.2))(graphql@16.11.0)
@@ -97,8 +97,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typia:
-        specifier: ^9.7.0
-        version: 9.7.0(typescript@5.9.2)
+        specifier: ^9.7.1
+        version: 9.7.1(typescript@5.9.2)
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
@@ -116,14 +116,14 @@ importers:
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.11.0)
       '@nestia/benchmark':
-        specifier: ^7.3.1
-        version: 7.3.2
+        specifier: ^7.3.3
+        version: 7.3.3
       '@nestia/e2e':
-        specifier: ^7.3.1
-        version: 7.3.2
+        specifier: ^7.3.3
+        version: 7.3.3
       '@nestia/sdk':
-        specifier: ^7.3.1
-        version: 7.3.2(@nestia/core@7.3.2(@nestia/fetcher@7.3.2)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.0(typescript@5.9.2)))(@types/node@18.19.121)(typescript@5.9.2)
+        specifier: ^7.3.3
+        version: 7.3.3(@nestia/core@7.3.3(@nestia/fetcher@7.3.3)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2)))(@types/node@18.19.121)(typescript@5.9.2)
       '@nestjs/cli':
         specifier: ^11.0.10
         version: 11.0.10(@types/node@18.19.121)(webpack-cli@5.1.4)
@@ -179,8 +179,8 @@ importers:
         specifier: ^4.18.2
         version: 4.21.2
       nestia:
-        specifier: ^7.3.1
-        version: 7.3.2
+        specifier: ^7.3.3
+        version: 7.3.3
       prettier:
         specifier: ^3.2.4
         version: 3.6.2
@@ -1249,13 +1249,13 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@nestia/benchmark@7.3.2':
-    resolution: {integrity: sha512-xGeUSuUc94JMv0hT0G/4i4fkOfuGVEInqsDf0cbvguusWxpj8zAjOLFsWmO7gTpvxantEyaW+WIbrmum8WzXSg==}
+  '@nestia/benchmark@7.3.3':
+    resolution: {integrity: sha512-y7tFa/4+o9pe901s+i5IqOW0caILpBIVk7go6sgP8GiE4ogtOnHygbMovcb6NFB0dII9MJ8lmRo7CJFB+CQ2FQ==}
 
-  '@nestia/core@7.3.2':
-    resolution: {integrity: sha512-wYaekM6iFlIZkkvZejoioBIjIHKuPfusRD9lLKb0vYQctPpUPHTH2dljMX6GXzsG+6vtXpAdD40e/2HRz+jLig==}
+  '@nestia/core@7.3.3':
+    resolution: {integrity: sha512-EtI5zCFI0yD18NoDl+mz0purLR/vEvHQYoN1yME2ymk8/TSaqF0WKYVlrJI4riAnXZW57ExJSwLfcKWE3EYGyg==}
     peerDependencies:
-      '@nestia/fetcher': '>=7.3.2'
+      '@nestia/fetcher': '>=7.3.3'
       '@nestjs/common': '>=7.0.1'
       '@nestjs/core': '>=7.0.1'
       '@samchon/openapi': '>=4.5.0 <5.0.0'
@@ -1263,17 +1263,17 @@ packages:
       rxjs: '>=6.0.3'
       typia: ^9.6.1
 
-  '@nestia/e2e@7.3.2':
-    resolution: {integrity: sha512-ZqiDUMuaPQ74gK9R2GKVETfnzL2wXKKBVoPamQ/m3CkJ80Q8VVCqgZ38sminWKaD0r3CthLh0gQCiXA+hAATcA==}
+  '@nestia/e2e@7.3.3':
+    resolution: {integrity: sha512-tLFzN/Dua0KGCvZ1DCrZOoC7kadYLZ+GYTLKgHEwJFXnJD9olyUM1RpXJ+I4m9p4f/mjjVJrH4C6rPGjfVZQ2A==}
 
-  '@nestia/fetcher@7.3.2':
-    resolution: {integrity: sha512-g7ShVYciZRuqneEMJlCvskn64GZWQ8w3nvBaBaiAEIvAMS5L8E5+3jYA7dVdYZiXimQ1No/fJLCp2Zjz7ytTqw==}
+  '@nestia/fetcher@7.3.3':
+    resolution: {integrity: sha512-wWRVRY9De5KlfB1sOvccEv/L9NEFDQQDyfyOUZfBRcjcK52CLzjoeUzDSPGYRwNsKaPjCXKRIq2+ica8oIkj2Q==}
 
-  '@nestia/sdk@7.3.2':
-    resolution: {integrity: sha512-MTJdQ499iNq7Mt/Om2Tv80GvoUoAUqZuJzV35/sYRUgmKCi1z1Qxh7h0LkghnRCjOXoNv9TmrernFOVOkEh7TA==}
+  '@nestia/sdk@7.3.3':
+    resolution: {integrity: sha512-qqnmPe70xBnCNiXB/cT/+bMx7EQa9A0oegXfW2RVOQgdv1JgcKl/3kF5TsghtTdF8EgIm/aMPZ+I5Mfp2R9Org==}
     hasBin: true
     peerDependencies:
-      '@nestia/core': '>=7.3.2'
+      '@nestia/core': '>=7.3.3'
 
   '@nestjs/apollo@13.1.0':
     resolution: {integrity: sha512-/FRg195AxpZ58Kjd7geeksaRs3blmlGMDUak7WGbrl7ZWX7J9VuulhTjVHP6Z+dhH4Tn+AsyjkkJ2euC8psv3A==}
@@ -4089,8 +4089,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  nestia@7.3.2:
-    resolution: {integrity: sha512-yzfpIKQ6Rq5qp3mO6IrhjT/Mo0afVKBu2VhO1un6TxwOstVTQcqI7QuanOQV8hK1dmpnGNHWVCsLnA3aROPbEg==}
+  nestia@7.3.3:
+    resolution: {integrity: sha512-ucf8zFLqXK1zvwS3MqcOnULCs/U38Sifp4ZwpAHoF47qwSOMORdI2Hzce9nWGhehW/pzrWsghbW22+ZlnQKbrw==}
     hasBin: true
 
   no-case@3.0.4:
@@ -5223,8 +5223,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typia@9.7.0:
-    resolution: {integrity: sha512-TjzPPlMfDED2dm3jYEVB0n7vgkCKrXCislI1c40JDjN58Cpog29odxlF6N/JsjN3LWXvjwi7DoOKwihE4U+giw==}
+  typia@9.7.1:
+    resolution: {integrity: sha512-HY9hhvAPhFvFHfjA3Ny1DmucUyrbsFalt+wr58oBJyNBFUxE6nTF8aJSpLOv1Bav6dZslNh39MEez0s7qLB1jw==}
     hasBin: true
     peerDependencies:
       typescript: '>=4.8.0 <5.10.0'
@@ -5777,7 +5777,7 @@ snapshots:
   '@autobe/interface@0.10.6(typescript@5.9.2)':
     dependencies:
       '@samchon/openapi': 4.6.0
-      typia: 9.7.0(typescript@5.9.2)
+      typia: 9.7.1(typescript@5.9.2)
     transitivePeerDependencies:
       - typescript
 
@@ -6368,9 +6368,9 @@ snapshots:
       '@graphql-tools/utils': 10.9.1(graphql@16.11.0)
       '@types/ws': 8.18.1
       graphql: 16.11.0
-      isomorphic-ws: 5.0.0(ws@8.18.1)
+      isomorphic-ws: 5.0.0(ws@8.18.3)
       tslib: 2.8.1
-      ws: 8.18.1
+      ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6541,10 +6541,10 @@ snapshots:
       '@whatwg-node/fetch': 0.10.10
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.11.0
-      isomorphic-ws: 5.0.0(ws@8.18.1)
+      isomorphic-ws: 5.0.0(ws@8.18.3)
       sync-fetch: 0.6.0-2
       tslib: 2.8.1
-      ws: 8.18.1
+      ws: 8.18.3
     transitivePeerDependencies:
       - '@fastify/websocket'
       - '@types/node'
@@ -6776,18 +6776,18 @@ snapshots:
       '@tybys/wasm-util': 0.10.0
     optional: true
 
-  '@nestia/benchmark@7.3.2':
+  '@nestia/benchmark@7.3.3':
     dependencies:
-      '@nestia/fetcher': 7.3.2
+      '@nestia/fetcher': 7.3.3
       tgrid: 1.2.0
       tstl: 3.0.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@nestia/core@7.3.2(@nestia/fetcher@7.3.2)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.0(typescript@5.9.2))':
+  '@nestia/core@7.3.3(@nestia/fetcher@7.3.3)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2))':
     dependencies:
-      '@nestia/fetcher': 7.3.2
+      '@nestia/fetcher': 7.3.3
       '@nestjs/common': 11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.6(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.6)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@samchon/openapi': 4.7.1
@@ -6799,23 +6799,23 @@ snapshots:
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
       tgrid: 1.2.0
-      typia: 9.7.0(typescript@5.9.2)
+      typia: 9.7.1(typescript@5.9.2)
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@nestia/e2e@7.3.2': {}
+  '@nestia/e2e@7.3.3': {}
 
-  '@nestia/fetcher@7.3.2':
+  '@nestia/fetcher@7.3.3':
     dependencies:
-      '@samchon/openapi': 4.6.0
+      '@samchon/openapi': 4.7.1
 
-  '@nestia/sdk@7.3.2(@nestia/core@7.3.2(@nestia/fetcher@7.3.2)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.0(typescript@5.9.2)))(@types/node@18.19.121)(typescript@5.9.2)':
+  '@nestia/sdk@7.3.3(@nestia/core@7.3.3(@nestia/fetcher@7.3.3)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2)))(@types/node@18.19.121)(typescript@5.9.2)':
     dependencies:
-      '@nestia/core': 7.3.2(@nestia/fetcher@7.3.2)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.0(typescript@5.9.2))
-      '@nestia/fetcher': 7.3.2
-      '@samchon/openapi': 4.6.0
+      '@nestia/core': 7.3.3(@nestia/fetcher@7.3.3)(@nestjs/common@11.1.6(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.6)(@samchon/openapi@4.7.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typia@9.7.1(typescript@5.9.2))
+      '@nestia/fetcher': 7.3.3
+      '@samchon/openapi': 4.7.1
       cli: 1.0.1
       get-function-location: 2.0.0
       glob: 11.0.3
@@ -6825,7 +6825,7 @@ snapshots:
       tsconfck: 2.1.2(typescript@5.9.2)
       tsconfig-paths: 4.2.0
       tstl: 3.0.0
-      typia: 9.7.0(typescript@5.9.2)
+      typia: 9.7.1(typescript@5.9.2)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
@@ -9675,10 +9675,6 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  isomorphic-ws@5.0.0(ws@8.18.1):
-    dependencies:
-      ws: 8.18.1
-
   isomorphic-ws@5.0.0(ws@8.18.3):
     dependencies:
       ws: 8.18.3
@@ -9973,7 +9969,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nestia@7.3.2:
+  nestia@7.3.3:
     dependencies:
       commander: 10.0.0
       comment-json: 4.2.5
@@ -11243,7 +11239,7 @@ snapshots:
 
   typescript@5.9.2: {}
 
-  typia@9.7.0(typescript@5.9.2):
+  typia@9.7.1(typescript@5.9.2):
     dependencies:
       '@samchon/openapi': 4.7.1
       '@standard-schema/spec': 1.0.0

--- a/typos.toml
+++ b/typos.toml
@@ -10,5 +10,13 @@ Jeongho = "Jeongho"
 Nam = "Nam"
 typia = "typia"
 
+[default.extend-identifiers]
+Ba = "Ba"
+BA = "BA"
+Fo = "Fo"
+FO = "FO"
+Pn = "Pn"
+PN = "PN"
+
 [files]
 extend-exclude = ["*.json"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated daily npm dependency updates for the web app.
  * Grouped updates by ecosystem: Vite (vite, vitest, vite-tsconfig-paths, @vitejs/plugin-react), React (react, react-dom, @types/react, @types/react-dom), and TypeScript (typescript).
  * Capped concurrent update pull requests at 25 and set versioning strategy to “increase.”
  * Restricted updates to key whitelisted packages to keep changes focused and manageable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->